### PR TITLE
Added setup.py

### DIFF
--- a/MacOSX/README
+++ b/MacOSX/README
@@ -46,6 +46,14 @@ Contributions are welcome :-)
 Enjoy,
 fG!
 
+---
+
+To build & install:
+
+# python setup.py install
+
+-snare.
+
 **** OLD INSTRUCTIONS, TO BE UPDATED ****
 
 Welcome to Pai Mei/PyDbg for Mac OS X.  This code is still under development so probably has bugs.  Please 

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,41 @@
+import os
+import subprocess
+from setuptools import setup
+
+def read(fname):
+    return open(os.path.join(os.path.dirname(__file__), fname)).read()
+
+def build_macdll():
+    print("Building libmacdll.dylib...")
+    print("-" * 30)
+    script = """
+    cd MacOSX/macdll
+    xcodebuild -target macdll -configuration {0}
+    cp -f build/{0}/libmacdll.dylib ../../pydbg
+    cp -f build/{0}/libmacdll.dylib ../../utils
+    """
+    build_config = "Debug"
+    res = subprocess.call(script.format(build_config), shell=True)
+    print("-" * 30)
+    if res != 0:
+        print("failed to build macdll")
+        exit
+
+build_macdll()
+
+setup(
+    name = "pydbg",
+    version = "0.0.1",
+    author = "fG!",
+    author_email = "reverser@put.as",
+    description = ("Port of PyDbg to Mac OS X on x86_64"),
+    license = "GPL",
+    keywords = "pydbg debug 64-bit",
+    url = "http://github.com/gdbinit/pydbg64",
+    packages=['pydbg'],
+    install_requires = ['pydot', 'wxPython', 'mysql-python'],
+    long_description=read('README'),
+    package_data = {
+        'pydbg': ['*.dylib'],
+    },
+)


### PR DESCRIPTION
I'm using the distribute package, should work OK with old setuptools too though I think. setup.py does the job of the macsetup.sh script with regard to installing dependencies and building macdll, along with actually installing the pydbg package into site-packages. I added instructions to MacOSX/README (python setup.py install... whoa!)
